### PR TITLE
Add sync_secrets script for syncing .env to GitHub Actions secrets

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -25,6 +25,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.PIPELINE_GITHUB_TOKEN }}
       GYM_GROUP_USERNAME: ${{ secrets.GYM_GROUP_USERNAME }}
       GYM_GROUP_PASSWORD: ${{ secrets.GYM_GROUP_PASSWORD }}
+      GARMIN_USERNAME: ${{ secrets.GARMIN_USERNAME }}
+      GARMIN_PASSWORD: ${{ secrets.GARMIN_PASSWORD }}
       JOBS_TO_RUN: ${{ github.event.inputs.jobs_to_run || '' }}
       SOURCES_TO_EXTRACT: ${{ github.event.inputs.sources_to_extract || '' }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install install-python install-node up down console setup-r2 pipeline export-json sync-macos install-macos-cron uninstall-macos-cron test dev build lint format clean
+.PHONY: help install install-python install-node up down console setup-r2 pipeline export-json sync-macos sync-secrets install-macos-cron uninstall-macos-cron test dev build lint format clean
 
 PLIST_LABEL = com.yearindata.macos
 PLIST_PATH  = ~/Library/LaunchAgents/$(PLIST_LABEL).plist
@@ -52,6 +52,9 @@ export-json: ## Export gold tables
 
 get-web-url: ## Print the public URL of the web R2 bucket
 	uv run python scripts/get_web_url.py
+
+sync-secrets: ## Push .env values to GitHub Actions secrets (ONLY=KEY1,KEY2 to filter)
+	bash scripts/sync_secrets.sh $(if $(ONLY),--only $(ONLY),)
 
 install-macos-cron: ## Install launchd job to sync screen time daily at 9 AM
 	mkdir -p $(PROJECT_DIR)/logs

--- a/scripts/sync_secrets.sh
+++ b/scripts/sync_secrets.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Reads .env and pushes each value as a GitHub Actions secret.
+# Usage: bash scripts/sync_secrets.sh [--env .env]
+
+set -euo pipefail
+
+ENV_FILE=".env"
+FILTER=()
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --env) ENV_FILE="$2"; shift 2 ;;
+    --only) IFS=',' read -ra FILTER <<< "$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  echo "Error: $ENV_FILE not found"
+  exit 1
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+if [[ -z "$REPO" ]]; then
+  echo "Error: not in a GitHub repo or not authenticated (run: gh auth login)"
+  exit 1
+fi
+
+echo "Syncing secrets to $REPO from $ENV_FILE..."
+
+while IFS= read -r line; do
+  # Skip comments and blank lines
+  [[ "$line" =~ ^[[:space:]]*# ]] && continue
+  [[ -z "${line// }" ]] && continue
+  # Skip lines without =
+  [[ "$line" != *"="* ]] && continue
+
+  key="${line%%=*}"
+  value="${line#*=}"
+
+  # Skip if key is empty
+  [[ -z "$key" ]] && continue
+
+  # Skip if not in filter list (when filter is set)
+  if [[ ${#FILTER[@]} -gt 0 ]]; then
+    match=0
+    for f in "${FILTER[@]}"; do
+      [[ "$key" == "$f" ]] && match=1 && break
+    done
+    [[ $match -eq 0 ]] && continue
+  fi
+
+  gh secret set "$key" --body "$value" --repo "$REPO"
+  echo "  ✓ $key"
+done < "$ENV_FILE"
+
+echo "Done."


### PR DESCRIPTION
## Summary

- Adds `scripts/sync_secrets.sh` — reads `.env` and pushes each key/value as a GitHub Actions secret via `gh secret set`. Supports `--only KEY1,KEY2` to sync a subset.
- Adds `make sync-secrets` (with optional `ONLY=` filter) as the Makefile entry point.
- Adds `GARMIN_USERNAME` and `GARMIN_PASSWORD` to the pipeline workflow env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)